### PR TITLE
Removes modulus operator in fastq#foreach for performance

### DIFF
--- a/src/bio/fastq_file.cr
+++ b/src/bio/fastq_file.cr
@@ -40,6 +40,7 @@ module Bio
           quality = line
           yield(header, sequence, description, quality)
         end
+      count += 1
       end
     end
   end

--- a/src/bio/fastq_file.cr
+++ b/src/bio/fastq_file.cr
@@ -28,7 +28,7 @@ module Bio
       each_line(*args) do |line|
         line = line.chomp
 
-        case count % 4
+        case count
         when 0
           header = line[1..-1]
         when 1
@@ -36,11 +36,10 @@ module Bio
         when 2
           description = line[1..-1]
         when 3
+          count = 0
           quality = line
           yield(header, sequence, description, quality)
         end
-
-        count += 1
       end
     end
   end


### PR DESCRIPTION
Should result in n fewer modulus calculations in exchange for a reassignment of count = 0 when a full record has been read.
